### PR TITLE
Fix for Client crash logs.

### DIFF
--- a/scripts/3_game/dayzgame.c
+++ b/scripts/3_game/dayzgame.c
@@ -1,0 +1,17 @@
+modded class DayZGame {
+    
+    override void OnRPC(PlayerIdentity sender, Object target, int rpc_type, ParamsReadContext ctx)
+	{
+        super.OnRPC(sender, target, rpc_type, ctx);
+		Event_OnRPC.Invoke(sender, target, rpc_type, ctx);
+
+        if (rpc_type == RPC_GEBSCONFIG_SYNC)
+        {
+            Param1<gebsfishConfig> configParams;
+            if(!ctx.Read(configParams))
+            return;
+            SetGebsfishConfig(configParams.param1);
+            Print("[gebsfish] Client received config data from the server.");
+        }
+    }
+}

--- a/scripts/3_game/gebsfishConfig.c
+++ b/scripts/3_game/gebsfishConfig.c
@@ -78,7 +78,7 @@ class gebsfishConfig {
     ref ContainerJunkConf ContainerJunk;
 
     void Load(){
-        if (GetGame().IsDedicatedServer() || GetGame().IsClient()){
+        if (GetGame().IsDedicatedServer()){
             if (FileExist(ModFolder + SettingsConfigFile)){
                 //If config exists, load file
                 JsonFileLoader<gebsfishConfig>.JsonLoadFile(ModFolder + SettingsConfigFile, this);

--- a/scripts/3_game/gebsfishConfig.c
+++ b/scripts/3_game/gebsfishConfig.c
@@ -1107,7 +1107,7 @@ static gebsfishConfig GetGebSettingsConfig(){
 
 static void SetGebsfishConfig(gebsfishConfig config)
 {
-    Print("Gebs fishing config Settings Received From Server");
+    Print("[gebsfish] Set config settings from server.");
     m_gebsConfig = config;
 }
 //Prevent double printing in log file since it loads the yield data twice

--- a/scripts/4_world/entities/manbase/geb_playerbase.c
+++ b/scripts/4_world/entities/manbase/geb_playerbase.c
@@ -17,17 +17,5 @@ modded class PlayerBase extends ManBase
             }
         }
 
-        switch(rpc_type)
-        {
-            case RPC_GEBSCONFIG_SYNC: // this case is for grabbing fishing config from the server
-            {
-                Param1<gebsfishConfig> configParams;
-                if(!ctx.Read(configParams))
-                    return;
-                SetGebsfishConfig(configParams.param1);
-                break;
-            }
-            Print("[gebsfish] Received config data from server");
-        }
     }
 }


### PR DESCRIPTION
Final fix for client crash logs due to config. Data is now transferred to the client in `MissionServer::OnClientPrepareEvent` and picked up by the client in `DayZGame::onRPC`